### PR TITLE
write and read temporary gcode file using utf8 encoding

### DIFF
--- a/ArcWelderPlugin.py
+++ b/ArcWelderPlugin.py
@@ -182,8 +182,8 @@ class ArcWelderPlugin(Extension):
                 joined_gcode = layer_separator.join(gcode_list)
 
                 file_descriptor, path = tempfile.mkstemp()
-                with os.fdopen(file_descriptor, 'w') as temporary_file:
-                    temporary_file.write(joined_gcode)
+                with os.fdopen(file_descriptor, "wb") as temporary_file:
+                    temporary_file.write(joined_gcode.encode("utf-8"))
 
                 command_arguments = [
                     self._arcwelder_path,
@@ -207,8 +207,8 @@ class ArcWelderPlugin(Extension):
                 command_arguments.append(path)
                 subprocess.run(command_arguments)
 
-                with open(path, "r") as temporary_file:
-                    result_gcode = temporary_file.read()
+                with open(path, "rb") as temporary_file:
+                    result_gcode = temporary_file.read().decode("utf-8")
                 os.remove(path)
 
                 gcode_list = result_gcode.split(layer_separator)


### PR DESCRIPTION
For some reason I have utf8 symbols in generated gcode, that gave me an error while saving file to sd card (only when arcwelder plugin was enabled). So I added utf8 encoding/decoding to temp file, and changed read/write mode to binary file that fixed plugin for me.